### PR TITLE
Updating to rails6 spree4.1

### DIFF
--- a/app/helpers/spree/admin/base_helper_decorator.rb
+++ b/app/helpers/spree/admin/base_helper_decorator.rb
@@ -1,4 +1,4 @@
-Spree::BaseHelper.class_eval do
+module Spree::Admin::BaseHelperDecorator
   def selected?(current_insight, insight)
     current_insight.eql?(insight)
   end
@@ -15,3 +15,5 @@ Spree::BaseHelper.class_eval do
     wicked_pdf_image_tag image_path, class: 'logo'
   end
 end
+
+::Spree::BaseHelper.prepend(Spree::Admin::BaseHelperDecorator)

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,3 +1,7 @@
-Spree::AppConfiguration.class_eval do
-  preference :records_per_page, :integer, default: 20
+module Spree::AppConfigurationDecorator
+  def self.prepend(base)
+    base.preference :records_per_page, :integer, default: 20
+  end
 end
+
+::Spree::AppConfiguration.prepend(Spree::AppConfigurationDecorator)

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,5 +1,5 @@
 module Spree::AppConfigurationDecorator
-  def self.prepend(base)
+  def self.prepended(base)
     base.preference :records_per_page, :integer, default: 20
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,5 +1,5 @@
 module Spree::ProductDecorator
-  def self.prepend(base)
+  def self.prepended(base)
     base.has_many :page_view_events, -> { viewed }, class_name: 'Spree::PageEvent', foreign_key: :target_id
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,3 +1,7 @@
-Spree::Product.class_eval do
-  has_many :page_view_events, -> { viewed }, class_name: 'Spree::PageEvent', foreign_key: :target_id
+module Spree::ProductDecorator
+  def self.prepend(base)
+    base.has_many :page_view_events, -> { viewed }, class_name: 'Spree::PageEvent', foreign_key: :target_id
+  end
 end
+
+::Spree::Product.prepend(Spree::ProductDecorator)

--- a/app/models/spree/promotion_action_decorator.rb
+++ b/app/models/spree/promotion_action_decorator.rb
@@ -1,3 +1,7 @@
-Spree::PromotionAction.class_eval do
-  has_one :adjustment, -> { promotion }, class_name: 'Spree::Adjustment', foreign_key: :source_id
+module Spree::PromotionActionDecorator
+  def self.prepend(base)
+    base.has_one :adjustment, -> { promotion }, class_name: 'Spree::Adjustment', foreign_key: :source_id
+  end
 end
+
+::Spree::PromotionAction.prepend(Spree::PromotionActionDecorator)

--- a/app/models/spree/promotion_action_decorator.rb
+++ b/app/models/spree/promotion_action_decorator.rb
@@ -1,5 +1,5 @@
 module Spree::PromotionActionDecorator
-  def self.prepend(base)
+  def self.prepended(base)
     base.has_one :adjustment, -> { promotion }, class_name: 'Spree::Adjustment', foreign_key: :source_id
   end
 end

--- a/app/models/spree/return_authorization_decorator.rb
+++ b/app/models/spree/return_authorization_decorator.rb
@@ -1,4 +1,8 @@
-Spree::ReturnAuthorization.class_eval do
-  has_many :variants, through: :inventory_units
-  has_many :products, through: :variants
+module Spree::ReturnAuthorizationDecorator
+  def self.prepend(base)
+    base.has_many :variants, through: :inventory_units
+    base.has_many :products, through: :variants
+  end
 end
+
+::Spree::ReturnAuthorization.prepend(Spree::ReturnAuthorizationDecorator)

--- a/app/models/spree/return_authorization_decorator.rb
+++ b/app/models/spree/return_authorization_decorator.rb
@@ -1,5 +1,5 @@
 module Spree::ReturnAuthorizationDecorator
-  def self.prepend(base)
+  def self.prepended(base)
     base.has_many :variants, through: :inventory_units
     base.has_many :products, through: :variants
   end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,5 +1,5 @@
 module Spree::UserDecorator
-  def self.prepend(base)
+  def self.prepended(base)
     base.has_many :spree_orders, class_name: 'Spree::Order'
   end
 end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,3 +1,7 @@
-Spree::User.class_eval do
-  has_many :spree_orders, class_name: 'Spree::Order'
+module Spree::UserDecorator
+  def self.prepend(base)
+    base.has_many :spree_orders, class_name: 'Spree::Order'
+  end
 end
+
+::Spree::User.prepend(Spree::UserDecorator)

--- a/app/overrides/add_insights_to_admin_side_menu.html.rb
+++ b/app/overrides/add_insights_to_admin_side_menu.html.rb
@@ -10,6 +10,6 @@ else
     virtual_path: 'spree/admin/shared/_main_menu',
     name: 'add_insights_to_admin_side_menu',
     insert_bottom: 'nav',
-    partial: 'spree/admin/shared/_insights_side_menu',
+    partial: 'spree/admin/shared/insights_side_menu',
   )
 end

--- a/app/overrides/add_insights_to_admin_side_menu.html.rb
+++ b/app/overrides/add_insights_to_admin_side_menu.html.rb
@@ -1,5 +1,15 @@
-Deface::Override.new(virtual_path: 'spree/layouts/admin',
-  name: 'add_insights_to_admin_side_menu',
-  insert_bottom: "[data-hook='admin_tabs'], #admin_tabs[data-hook]",
-  partial: 'spree/admin/shared/insights_side_menu',
-)
+if Spree.version.to_f < 4.0
+  Deface::Override.new(
+    virtual_path: 'spree/layouts/admin',
+    name: 'add_insights_to_admin_side_menu',
+    insert_bottom: "[data-hook='admin_tabs'], #admin_tabs[data-hook]",
+    partial: 'spree/admin/shared/insights_side_menu',
+  )
+else
+  Deface::Override.new(
+    virtual_path: 'spree/admin/shared/_main_menu',
+    name: 'add_insights_to_admin_side_menu',
+    insert_bottom: 'nav',
+    partial: 'spree/admin/shared/_insights_side_menu',
+  )
+end

--- a/app/views/spree/admin/insights/index.html.erb
+++ b/app/views/spree/admin/insights/index.html.erb
@@ -76,6 +76,7 @@
           <li><%= link_to 'PDF', admin_insights_download_path(format: 'pdf'), class: 'download-link', data: { url: admin_insights_download_path(format: 'pdf') }%></li>
         </ul>
       </span>
+    </span>
     </div>
   </div>
 
@@ -84,7 +85,6 @@
 
   <div id='paginator-div'>
   </div>
-</div>
 
 <%= render partial: 'spree/admin/templates/insights/show', formats: [:template] %>
 <%= render partial: 'spree/admin/templates/insights/paginator', formats: [:template] %>

--- a/app/views/spree/admin/shared/_insights_side_menu.html.erb
+++ b/app/views/spree/admin/shared/_insights_side_menu.html.erb
@@ -1,14 +1,14 @@
 <% if can? :admin, Spree::Admin::InsightsController %>
-  <ul class="nav nav-sidebar">
-    <li class="sidebar-menu-item">
-      <a data-toggle="collapse" data-parent="#sidebar" href="#sidebar-insights">
-        <span class="icon icon-stats"></span>
+  <ul class="nav nav-sidebar border-bottom">
+    <li class="sidebar-menu-item d-block w-100">
+      <a data-toggle="collapse" class="d-flex w-100 p-3 position-relative align-items-center" data-parent="#sidebar" href="#sidebar-insights">
+        <span class="icon icon-stats mr-2"></span>
         <span class="text"> <%= Spree.t(:tab_heading, scope: :insight) %></span>
-        <span class="icon icon-chevron-left pull-right"></span>
+        <span class="icon icon-chevron-left position-absolute"></span>
       </a>
-      <ul data-hook="admin_configurations_sidebar_menu" class="collapse nav nav-pills nav-stacked" id="sidebar-insights">
+      <ul data-hook="admin_configurations_sidebar_menu" class="border-top bg-white collapse nav nav-pills nav-stacked" id="sidebar-insights">
         <% Spree::ReportGenerationService.reports.each do |_key, _value| %>
-          <li class="sidebar-menu-item <%= (selected?(params[:report_category], _key) ? 'selected' : '') %>"><%= link_to Spree.t(_key), admin_insight_path(report_category: _key, id: _value.first)  %></li>
+          <li class="sidebar-menu-item d-block w-100 <%= (selected?(params[:report_category], _key) ? 'selected' : '') %>"><%= link_to Spree.t(_key), admin_insight_path(report_category: _key, id: _value.first, class: " py-1 px-3 d-block sidebar-submenu-item")  %></li>
         <% end %>
       </ul>
     </li>

--- a/app/views/spree/admin/shared/_insights_side_menu.html.erb
+++ b/app/views/spree/admin/shared/_insights_side_menu.html.erb
@@ -1,14 +1,14 @@
 <% if can? :admin, Spree::Admin::InsightsController %>
   <ul class="nav nav-sidebar border-bottom">
     <li class="sidebar-menu-item d-block w-100">
-      <a data-toggle="collapse" class="d-flex w-100 p-3 position-relative align-items-center" data-parent="#sidebar" href="#sidebar-insights">
+      <a data-toggle="collapse" class="d-flex w-100 p-3 position-relative align-items-center" href="#sidebar-insights">
         <span class="icon icon-stats mr-2"></span>
         <span class="text"> <%= Spree.t(:tab_heading, scope: :insight) %></span>
         <span class="icon icon-chevron-left position-absolute"></span>
       </a>
       <ul data-hook="admin_configurations_sidebar_menu" class="border-top bg-white collapse nav nav-pills nav-stacked" id="sidebar-insights">
         <% Spree::ReportGenerationService.reports.each do |_key, _value| %>
-          <li class="sidebar-menu-item d-block w-100 <%= (selected?(params[:report_category], _key) ? 'selected' : '') %>"><%= link_to Spree.t(_key), admin_insight_path(report_category: _key, id: _value.first, class: " py-1 px-3 d-block sidebar-submenu-item")  %></li>
+          <li class="sidebar-menu-item d-block w-100 <%= (selected?(params[:report_category], _key) ? 'selected' : '') %>"><%= link_to Spree.t(_key), admin_insight_path(report_category: _key, id: _value.first), class: " py-1 px-3 d-block sidebar-submenu-item" %></li>
         <% end %>
       </ul>
     </li>

--- a/spree_admin_insights.gemspec
+++ b/spree_admin_insights.gemspec
@@ -15,10 +15,11 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '>= 3.1.0', '< 4.0.0'
+  spree_version = '>= 3.1.0', '< 5.0.0'
 
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_extension'
+  s.add_dependency 'deface', '~> 1.5.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
### Changes
----
- Actualizado los decoradores para Rails 6 y Spree 4.1. Ademas, arregle que en el draft estaba mal, `self.prepend` por `self.prepended` en la declaración de los métodos.
- Mantuve deface esta vez, entonces actualice el `Override` para que funcione tanto para Spree3.x como para Spree4.x, e.j
```Ruby
if Spree.version.to_f < 4.0
  Deface::Override.new(
   # ....
  )
else
  Deface::Override.new(
    # ....  
  )
end
```
### Issues
Todos los request de `Insights` fallan, con un `records_per_page preference not defined`.
`records_per_page` se define en el decorador `app/models/spree/app_configuration_decorator.rb` el cual extiende el modelo `AppConfiguration` de Spree al hacerle `prepend`.
```Ruby
module Spree::AppConfigurationDecorator
  def self.prepended(base)
    base.preference :records_per_page, :integer, default: 20
  end
end

::Spree::AppConfiguration.prepend(Spree::AppConfigurationDecorator)
```

`records_per_page` es usado en el controlador `Insights` en el método [set_default_pagination](https://github.com/katapulk/spree-admin-insights/blob/ec937f0c1d26e63f754efaeb758d99f7d4727a24/app/controllers/spree/admin/insights_controller.rb#L102) y en la vista [index.html.erb](https://github.com/katapulk/spree-admin-insights/blob/ec937f0c1d26e63f754efaeb758d99f7d4727a24/app/views/spree/admin/insights/index.html.erb#L44). La razón de este error es que `Spree::Config[:records_per_page]` no encuentra la preferencia `records_per_page` definida en el modelo `AppConfiguration` de Spree, pero eso se supone que es lo que este definiendo el decorador. Si cambio estas dos ocurrencias de `Spree::Config[:records_per_page]`, por un valor por default hard coded, todo funciona bien.